### PR TITLE
Do not rely on english error message when checking cutlass existence

### DIFF
--- a/autoload/yoink.vim
+++ b/autoload/yoink.vim
@@ -29,7 +29,7 @@ let s:isCutlassInstalled = 0
 try
     call cutlass#getVersion()
     let s:isCutlassInstalled = 1
-catch /\VUnknown function/
+catch /\Vcutlass#getVersion/
 endtry
 
 if s:isCutlassInstalled && !g:yoinkIncludeDeleteOperations


### PR DESCRIPTION
Problem:
My vim reports errors in non-English language so that check for `Unknown function` does not work

Solution:
Look or a problem with a call to `cutlass#getVersion` rather than an error message